### PR TITLE
fix dependency error

### DIFF
--- a/assets/src/pages/cronjob/ModalTaskDetail.tsx
+++ b/assets/src/pages/cronjob/ModalTaskDetail.tsx
@@ -2,7 +2,7 @@ import {ModalProps} from "antd/es/modal";
 import {Badge, Descriptions, message, Modal} from "antd";
 import React, {useEffect, useState} from "react";
 import {Task, TaskDetail, TaskStatus} from "@/models/cronjob/types";
-import ProSkeleton from "@ant-design/pro-skeleton/src/index";
+import ProSkeleton from "@ant-design/pro-skeleton/lib/index";
 import MonacoEditor from "react-monaco-editor/lib/editor";
 import {fetchTaskDetail} from "@/services/taskplatform";
 import {PresetStatusColorType} from "antd/lib/_util/colors";


### PR DESCRIPTION
npm run start 出现错误

```js
This dependency was not found:

* @ant-design/pro-skeleton/src/index in ./src/pages/cronjob/ModalTaskDetail.tsx

To install it, you can run: npm install --save @ant-design/pro-skeleton/src/index
```

查看 node_modules/@ant-design/pro-skeleton 目录下没有 src文件夹，换成 lib 文件夹就好了
